### PR TITLE
small refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 parse_env
+*.tar.bz2


### PR DESCRIPTION
- reuse `httplib.HTTPSConnection()`
- use `sys.stdout.write()` instead of print 
- better timing output with `time.time()`
- `cleanup()` in exception
- better error logging with `traceback.format_exc()`

new output:

```
$ ./parse_export.py -f test.tar.bz2 -o User,Posts
---- beginning parse object dump: 2015-09-21 20:21:09 +0000 ----
retrieving User objects...
  retrieved 649 objects with 2 reqs for User in 1.8983 seconds
retrieving Posts objects...
  retrieved 40070 objects with 42 reqs for Posts in 63.9428 seconds
building archive...  done. (in 5.6057 seconds)
cleaning up: /tmp/test-gkckBB
---- completed parse object dump: 2015-09-21 20:22:21 +0000 ----
```
